### PR TITLE
Fix kernel usage in RunDiscordBotCommandTest

### DIFF
--- a/tests/Command/RunDiscordBotCommandTest.php
+++ b/tests/Command/RunDiscordBotCommandTest.php
@@ -58,17 +58,17 @@ class RunDiscordBotCommandTest extends KernelTestCase
 	/**
 	 * @throws Exception
 	 */
-	protected function setUp(): void
-	{
-		self::bootKernel();
-		$this->discordServiceMock = $this->createMock(DiscordService::class);
+        protected function setUp(): void
+        {
+                $kernel = self::bootKernel();
+                $this->discordServiceMock = $this->createMock(DiscordService::class);
 
-		$application = new Application(self::$kernel);
+                $application = new Application($kernel);
 
-		self::$kernel->getContainer()->set(DiscordService::class, $this->discordServiceMock);
+                $kernel->getContainer()->set(DiscordService::class, $this->discordServiceMock);
 
-		$command = $application->find('app:run-discord-bot');
+                $command = $application->find('app:run-discord-bot');
 
-		$this->commandTester = new CommandTester($command);
-	}
+                $this->commandTester = new CommandTester($command);
+        }
 }


### PR DESCRIPTION
## 📝 Description
- avoid null KernelInterface by capturing bootKernel() result

## 🛠️ Changements apportés
- `tests/Command/RunDiscordBotCommandTest.php`

## 🖥️ Étapes pour tester
- `composer install`
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse --memory-limit=512M --error-format=table`


------
https://chatgpt.com/codex/tasks/task_b_6883b19e429c833382bb85097791c9c8